### PR TITLE
Adds support for existing db and user

### DIFF
--- a/src/postgresql/pgolap.tcl
+++ b/src/postgresql/pgolap.tcl
@@ -68,12 +68,43 @@ pg_result $result -clear
 return $lda
 }
 
-proc CreateUserDatabase { lda db superuser user password } {
+proc CreateUserDatabase { lda host port db tspace superuser superuser_password user password } {
+set stmnt_count 1
 puts "CREATING DATABASE $db under OWNER $user"
-set sql(1) "CREATE USER $user PASSWORD '$password'"
-set sql(2) "GRANT $user to $superuser"
-set sql(3) "CREATE DATABASE $db OWNER $user"
-for { set i 1 } { $i <= 3 } { incr i } {
+set result [ pg_exec $lda "SELECT 1 FROM pg_roles WHERE rolname = '$user'"]
+if { [pg_result $result -numTuples] == 0 } {
+set sql($stmnt_count) "CREATE USER $user PASSWORD '$password'"
+incr stmnt_count;
+set sql($stmnt_count) "GRANT $user to $superuser"
+    } else {
+puts "Using existing User $user for Schema build"
+set sql($stmnt_count) "ALTER USER $user PASSWORD '$password'"
+    }
+incr stmnt_count;
+set result [ pg_exec $lda "SELECT 1 FROM pg_database WHERE datname = '$db'"]
+if { [pg_result $result -numTuples] == 0} {
+set sql($stmnt_count) "CREATE DATABASE $db OWNER $user"
+    } else {
+set existing_db [ ConnectToPostgres $host $port $superuser $superuser_password $db ]
+if { $existing_db eq "Failed" } {
+error "error, the database connection to $host could not be established"
+        } else {
+set result [ pg_exec $existing_db "SELECT 1 FROM pg_tables WHERE schemaname = 'public'"]
+if { [pg_result $result -numTuples] == 0 } {
+puts "Using existing empty Database $db for Schema build"
+set sql($stmnt_count) "ALTER DATABASE $db OWNER TO $user"
+            } else {
+puts "Database with tables $db exists"
+error "Database $db exists but is not empty, specify a new or empty database name"
+            }
+        }
+pg_disconnect $existing_db
+    }
+if { $tspace != "pg_default" } {
+incr stmnt_count
+set sql($stmnt_count) "ALTER DATABASE $db SET TABLESPACE $tspace"
+}
+for { set i 1 } { $i <= $stmnt_count } { incr i } {
 set result [ pg_exec $lda $sql($i) ]
 if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
 error "[pg_result $result -error]"
@@ -575,7 +606,7 @@ set lda [ ConnectToPostgres $host $port $superuser $superuser_password $defaultd
 if { $lda eq "Failed" } {
 error "error, the database connection to $host could not be established"
  } else {
-CreateUserDatabase $lda $db $superuser $user $password
+CreateUserDatabase $lda $host $port $db "pg_default" $superuser $superuser_password $user $password
 set result [ pg_exec $lda "commit" ]
 pg_result $result -clear
 pg_disconnect $lda

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -1350,12 +1350,43 @@ pg_result $result -clear
 return $lda
 }
 
-proc CreateUserDatabase { lda db superuser user password } {
+proc CreateUserDatabase { lda host port db tspace superuser superuser_password user password } {
+set stmnt_count 1
 puts "CREATING DATABASE $db under OWNER $user"  
-set sql(1) "CREATE USER $user PASSWORD '$password'"
-set sql(2) "GRANT $user to $superuser"
-set sql(3) "CREATE DATABASE $db OWNER $user"
-for { set i 1 } { $i <= 3 } { incr i } {
+set result [ pg_exec $lda "SELECT 1 FROM pg_roles WHERE rolname = '$user'"]
+if { [pg_result $result -numTuples] == 0 } {
+set sql($stmnt_count) "CREATE USER $user PASSWORD '$password'"
+incr stmnt_count;
+set sql($stmnt_count) "GRANT $user to $superuser"
+    } else {
+puts "Using existing User $user for Schema build"
+set sql($stmnt_count) "ALTER USER $user PASSWORD '$password'"
+    }
+incr stmnt_count;
+set result [ pg_exec $lda "SELECT 1 FROM pg_database WHERE datname = '$db'"]
+if { [pg_result $result -numTuples] == 0} {
+set sql($stmnt_count) "CREATE DATABASE $db OWNER $user"
+    } else {
+set existing_db [ ConnectToPostgres $host $port $superuser $superuser_password $db ]
+if { $existing_db eq "Failed" } {
+error "error, the database connection to $host could not be established"
+        } else {
+set result [ pg_exec $existing_db "SELECT 1 FROM pg_tables WHERE schemaname = 'public'"]
+if { [pg_result $result -numTuples] == 0 } {
+puts "Using existing empty Database $db for Schema build"
+set sql($stmnt_count) "ALTER DATABASE $db OWNER TO $user"
+            } else {
+puts "Database with tables $db exists"
+error "Database $db exists but is not empty, specify a new or empty database name"
+            }
+        }
+pg_disconnect $existing_db
+    }
+if { $tspace != "pg_default" } {
+incr stmnt_count
+set sql($stmnt_count) "ALTER DATABASE $db SET TABLESPACE $tspace"
+}
+for { set i 1 } { $i <= $stmnt_count } { incr i } {
 set result [ pg_exec $lda $sql($i) ]
 if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
 error "[pg_result $result -error]"
@@ -1833,7 +1864,7 @@ set lda [ ConnectToPostgres $host $port $superuser $superuser_password $defaultd
 if { $lda eq "Failed" } {
 error "error, the database connection to $host could not be established"
  } else {
-#CreateUserDatabase $lda $db $superuser $user $password
+CreateUserDatabase $lda $host $port $db "pg_default" $superuser $superuser_password $user $password
 set result [ pg_exec $lda "commit" ]
 pg_result $result -clear
 pg_disconnect $lda


### PR DESCRIPTION
This checks if the user exists, creates if not and alters the password if it does. Likewise, checks if empty database exists, if not creates and if it does alters the owner. If the database exists but is not empty, gives an error.

The indentation and the error messages are my best efforts to do something similar to the rest of the code. They're open for suggestions.

This PR is not meant to be merged. The actual PR will be opened at the actual repo. This is only for internal reviews from Citus.